### PR TITLE
Update README.md to use correct package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ function greet(name) {
 
 ```javascript
 import Markdown from 'react-markdown'
-import * as renderers from 'react-github-markdown-renderers'
+import renderers from 'react-markdown-github-renderers'
 
 const markdown = /* consider the above markdown */
 


### PR DESCRIPTION
The package name in the example is currently incorrect. Also when trying out this package, I could only get it to work by changing the import statement to import the default directly (as that is what is exported).